### PR TITLE
Correct sourcemap URLs if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ plugins: [
   new HtmlWebpackInlineSourcePlugin()
 ]  
 ```
+
+Sourcemaps
+----------
+If any source files contain a sourceMappingURL directive that isn't a data URI, then the sourcemap URL is corrected to be relative to the domain root (unless it already is) instead of the original source file.

--- a/README.md
+++ b/README.md
@@ -46,4 +46,11 @@ plugins: [
 
 Sourcemaps
 ----------
-If any source files contain a sourceMappingURL directive that isn't a data URI, then the sourcemap URL is corrected to be relative to the domain root (unless it already is) instead of the original source file.
+If any source files contain a sourceMappingURL directive that isn't a data URI, then the sourcemap URL is corrected to be relative to the domain root (unless it already is) instead of to the original source file.
+
+All sourcemap comment styles are supported:
+
+* `//# ...`
+* `//@ ...`
+* `/*# ...*/`
+* `/*@ ...*/`

--- a/index.js
+++ b/index.js
@@ -63,9 +63,11 @@ HtmlWebpackInlineSourcePlugin.prototype.resolveSourceMaps = function (compilatio
   var assetDir = path.dirname(assetPath);
   var mapPath = path.join(assetDir, mapUrlOriginal);
   var mapPathRelative = path.relative(out.path, mapPath);
+  // Starting with Node 6, `path` module throws on `undefined`
+  var publicPath = out.publicPath || '';
   // Prepend Webpack public URL path to source map relative path
   // Calling `slash` converts Windows backslashes to forward slashes
-  var mapUrlCorrected = slash(path.join(out.publicPath, mapPathRelative));
+  var mapUrlCorrected = slash(path.join(publicPath, mapPathRelative));
   // Regex: exact original sourcemap URL, possibly '*/' (for CSS), then EOF, ignoring whitespace
   var regex = new RegExp(escapeRegex(mapUrlOriginal) + '(\\s*(?:\\*/)?\\s*$)');
   // Replace sourcemap URL and (if necessary) preserve closing '*/' and whitespace

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 'use strict';
 var assert = require('assert');
+var escapeRegex = require('escape-string-regexp');
+var path = require('path');
+var slash = require('slash');
+var sourceMapUrl = require('source-map-url');
 
 function HtmlWebpackInlineSourcePlugin (options) {
   assert.equal(options, undefined, 'The HtmlWebpackInlineSourcePlugin does not accept any options');
@@ -44,12 +48,38 @@ HtmlWebpackInlineSourcePlugin.prototype.processTags = function (compilation, reg
   return { head: head, body: body };
 };
 
+HtmlWebpackInlineSourcePlugin.prototype.resolveSourceMaps = function (compilation, assetName, asset) {
+  var source = asset.source();
+  var out = compilation.outputOptions;
+  // Get asset file absolute path
+  var assetPath = path.join(out.path, assetName);
+  // Extract original sourcemap URL from source string
+  var mapUrlOriginal = sourceMapUrl.getFrom(source);
+  // Return unmodified source if map is unspecified, URL-encoded, or already relative to site root
+  if (!mapUrlOriginal || mapUrlOriginal.indexOf('data:') === 0 || mapUrlOriginal.indexOf('/') === 0) {
+    return source;
+  }
+  // Figure out sourcemap file path *relative to the asset file path*
+  var assetDir = path.dirname(assetPath);
+  var mapPath = path.join(assetDir, mapUrlOriginal);
+  var mapPathRelative = path.relative(out.path, mapPath);
+  // Prepend Webpack public URL path to source map relative path
+  // Calling `slash` converts Windows backslashes to forward slashes
+  var mapUrlCorrected = slash(path.join(out.publicPath, mapPathRelative));
+  // Regex: exact original sourcemap URL, possibly '*/' (for CSS), then EOF, ignoring whitespace
+  var regex = new RegExp(escapeRegex(mapUrlOriginal) + '(\\s*(?:\\*/)?\\s*$)');
+  // Replace sourcemap URL and (if necessary) preserve closing '*/' and whitespace
+  return source.replace(regex, function (match, group) {
+    return mapUrlCorrected + group;
+  });
+};
+
 HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, regex, tag) {
-  var assetPath;
+  var assetUrl;
 
   // inline js
   if (tag.tagName === 'script' && regex.test(tag.attributes.src)) {
-    assetPath = tag.attributes.src;
+    assetUrl = tag.attributes.src;
     tag = {
       tagName: 'script',
       closeTag: true,
@@ -60,7 +90,7 @@ HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, rege
 
   // inline css
   } else if (tag.tagName === 'link' && regex.test(tag.attributes.href)) {
-    assetPath = tag.attributes.href;
+    assetUrl = tag.attributes.href;
     tag = {
       tagName: 'style',
       closeTag: true,
@@ -70,15 +100,13 @@ HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, rege
     };
   }
 
-  if (assetPath) {
-    var asset = compilation.assets[assetPath.split('/').pop()];
-
-    // Look up full path if partial path not found
-    if (!asset) {
-      asset = compilation.assets[assetPath];
-    }
-
-    tag.innerHTML = asset.source();
+  if (assetUrl) {
+    // Strip public URL prefix from asset URL to get Webpack asset name
+    var publicUrlPrefix = compilation.outputOptions.publicPath;
+    var assetName = path.posix.relative(publicUrlPrefix, assetUrl);
+    var asset = compilation.assets[assetName];
+    var updatedSource = this.resolveSourceMaps(compilation, assetName, asset);
+    tag.innerHTML = updatedSource;
   }
 
   return tag;

--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
     "semistandard": "^7.0.5",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.0"
+  },
+  "dependencies": {
+    "escape-string-regexp": "^1.0.5",
+    "slash": "^1.0.0",
+    "source-map-url": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-webpack-inline-source-plugin",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Embed javascript and css source inline when using the webpack dev server or middleware",
   "main": "index.js",
   "files": [

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -46,11 +46,18 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
     webpack({
       entry: path.join(__dirname, 'fixtures', 'entry.js'),
       output: {
+        // filename with directory tests sourcemap URL correction
+        filename: 'bin/app.js',
+        // public path required to test sourcemap URL correction, but also for this bug work-around:
+        // https://github.com/webpack/webpack/issues/3242#issuecomment-260411104
+        publicPath: '/assets',
         path: OUTPUT_DIR
       },
       module: {
         loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
       },
+      // generate sourcemaps for testing URL correction
+      devtool: '#source-map',
       plugins: [
         new ExtractTextPlugin('style.css'),
         new HtmlWebpackPlugin({
@@ -65,7 +72,9 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         expect(er).toBeFalsy();
         var $ = cheerio.load(data);
         expect($('script').html()).toContain('.embedded.source');
+        expect($('script').html()).toContain('//# sourceMappingURL=/assets/bin/app.js.map');
         expect($('style').html()).toContain('.embedded.source');
+        expect($('style').html()).toContain('/*# sourceMappingURL=/assets/style.css.map');
         done();
       });
     });


### PR DESCRIPTION
In each source file, we check for a sourcemap URL directive. If we find one, we replace its URL with the sourcemap's full path relative to the domain root (i.e. the new URL will start with `/`). If the original sourcemap URL is a data URI or begins with `/` already, we don't touch it.

This PR also adds sourcemap correction to the tests, with different levels of path nesting.

I added a few tiny dependencies in this PR, because that's a lesser evil than reinventing the wheel completely 😃

Oh, and a small bonus: I tweaked how we look up assets from `compilation.assets`. We now take into account `compilation.outputOptions.publicPath`, so we can figure out the exact asset name without having to retry different parts of the path/filename. 👍

This PR closes issue #6.