### PR TITLE
Strip query strings from asset URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,8 @@ HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, rege
   }
 
   if (assetUrl) {
+    // Strip hash (i.e. for cache busting) from URL
+    assetUrl = assetUrl.replace(/\?.*$/, '');
     // Strip public URL prefix from asset URL to get Webpack asset name
     var publicUrlPrefix = compilation.outputOptions.publicPath;
     var assetName = path.posix.relative(publicUrlPrefix, assetUrl);

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, rege
   }
 
   if (assetUrl) {
-    // Strip hash (i.e. for cache busting) from URL
+    // Strip query string (e.g. cache busting hash) from asset URL
     assetUrl = assetUrl.replace(/\?.*$/, '');
     // Strip public URL prefix from asset URL to get Webpack asset name
     var publicUrlPrefix = compilation.outputOptions.publicPath;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-webpack-inline-source-plugin",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Embed javascript and css source inline when using the webpack dev server or middleware",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
This is primarily to enable compatibility with the cache-busting `hash` option of [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin).