### PR TITLE
Fix interop with other plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ HtmlWebpackInlineSourcePlugin.prototype.apply = function (compiler) {
     compilation.plugin('html-webpack-plugin-alter-asset-tags', function (htmlPluginData, callback) {
       // Skip if the plugin configuration didn't set `inlineSource`
       if (!htmlPluginData.plugin.options.inlineSource) {
-        return callback(null);
+        return callback(null, htmlPluginData);
       }
 
       var regexStr = htmlPluginData.plugin.options.inlineSource;
@@ -45,7 +45,7 @@ HtmlWebpackInlineSourcePlugin.prototype.processTags = function (compilation, reg
     body.push(self.processTag(compilation, regex, tag));
   });
 
-  return { head: head, body: body };
+  return { head: head, body: body, plugin: pluginData.plugin, chunks: pluginData.chunks, outputName: pluginData.outputName };
 };
 
 HtmlWebpackInlineSourcePlugin.prototype.resolveSourceMaps = function (compilation, assetName, asset) {


### PR DESCRIPTION
When using this plugin with other plugins attaching to the same hooks, the callback result will become the htmlPluginData object for the next plugin, so unmodified properties need to be copied or they will be lost.

I ran into this problem when using html-webpack-exclude-assets-plugin, which suffers from the same bug. Patching this in both plugins solved the issue.

See also [the corresponding issue on the other repo](https://github.com/jamesjieye/html-webpack-exclude-assets-plugin/pull/8). I'm not sure what these plugins are based on but I'm suspecting at some point someone blindly copied what the html-webpack-plugin unit tests are doing without consulting the actual implementation.