### PR TITLE
Don't strip query string from asset URL. Add test for such URLs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,8 +106,6 @@ HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, rege
   }
 
   if (assetUrl) {
-    // Strip query string (e.g. cache busting hash) from asset URL
-    assetUrl = assetUrl.replace(/\?.*$/, '');
     // Strip public URL prefix from asset URL to get Webpack asset name
     var publicUrlPrefix = compilation.outputOptions.publicPath || '';
     var assetName = path.posix.relative(publicUrlPrefix, assetUrl);

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -80,6 +80,38 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
     });
   });
 
+  it('should embed sources inline even if a query string hash is used', function (done) {
+    webpack({
+      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      output: {
+        // filename with output hash
+        filename: 'app.js?[hash]',
+        path: OUTPUT_DIR
+      },
+      module: {
+        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+      },
+      plugins: [
+        new ExtractTextPlugin('style.css?[hash]'),
+        new HtmlWebpackPlugin({
+          // modified regex to accept query string
+          inlineSource: '.(js|css)(\\?.*)?$'
+        }),
+        new HtmlWebpackInlineSourcePlugin()
+      ]
+    }, function (err) {
+      expect(err).toBeFalsy();
+      var htmlFile = path.resolve(OUTPUT_DIR, 'index.html');
+      fs.readFile(htmlFile, 'utf8', function (er, data) {
+        expect(er).toBeFalsy();
+        var $ = cheerio.load(data);
+        expect($('script').html()).toContain('.embedded.source');
+        expect($('style').html()).toContain('.embedded.source');
+        done();
+      });
+    });
+  });
+
   it('should embed source and not error if public path is undefined', function (done) {
     webpack({
       entry: path.join(__dirname, 'fixtures', 'entry.js'),


### PR DESCRIPTION
Assets with query-string'd URLs (e.g. Webpack output file `"bin/app.js?[hash]"`) are actually keyed in Webpack's compilation asset map *with* the query string, so stripping it beforehand was a mistake and caused an error.

I've also added a test for query string behavior, in case I mess this up again in the future. :wink: