### PR TITLE
Resources on the head

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,12 @@ HtmlWebpackInlineSourcePlugin.prototype.processTags = function (compilation, reg
   });
 
   pluginData.body.forEach(function (tag) {
-    body.push(self.processTag(compilation, regex, tag));
+    var sourceName = tag.attributes.src.split('/').reverse()[0] || '';
+    if (sourceName && regex.test(sourceName)) {
+      head.push(self.processTag(compilation, regex, tag));
+    }else {
+      body.push(self.processTag(compilation, regex, tag));      
+    }
   });
 
   return { head: head, body: body, plugin: pluginData.plugin, chunks: pluginData.chunks, outputName: pluginData.outputName };


### PR DESCRIPTION
The extracted resources are small enough that we should put it in the head to load