### PR TITLE
asset name matching fixed

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,12 +109,23 @@ HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, rege
     // Strip public URL prefix from asset URL to get Webpack asset name
     var publicUrlPrefix = compilation.outputOptions.publicPath || '';
     var assetName = path.posix.relative(publicUrlPrefix, assetUrl);
-    var asset = compilation.assets[assetName];
+    var asset = getAssetByName(compilation.assets, assetName);
     var updatedSource = this.resolveSourceMaps(compilation, assetName, asset);
     tag.innerHTML = (tag.tagName === 'script') ? updatedSource.replace(/(<)(\/script>)/g, '\\x3C$2') : updatedSource;
   }
 
   return tag;
 };
+
+function getAssetByName(assests, assetName) {
+  for (var key in assests) {
+    if (assests.hasOwnProperty(key)) {
+      var processedKey = path.posix.relative('', key);
+      if (processedKey === assetName) {
+          return assests[key];
+      }
+    }
+  }
+}
 
 module.exports = HtmlWebpackInlineSourcePlugin;

--- a/index.js
+++ b/index.js
@@ -117,12 +117,12 @@ HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, rege
   return tag;
 };
 
-function getAssetByName(assests, assetName) {
+function getAssetByName (assests, assetName) {
   for (var key in assests) {
     if (assests.hasOwnProperty(key)) {
       var processedKey = path.posix.relative('', key);
       if (processedKey === assetName) {
-          return assests[key];
+        return assests[key];
       }
     }
   }


### PR DESCRIPTION
path './smth/fi.le' and 'smth/fi.le' are not equal in current implementation

it produces incompatible with ExtractTextPlugin for example