### PR TITLE
Webpack 4 support added

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,18 +13,18 @@ HtmlWebpackInlineSourcePlugin.prototype.apply = function (compiler) {
   var self = this;
 
   // Hook into the html-webpack-plugin processing
-  compiler.plugin('compilation', function (compilation) {
-    compilation.plugin('html-webpack-plugin-alter-asset-tags', function (htmlPluginData) {
+  compiler.hooks.compilation.tap('html-webpack-inline-source-plugin', function (compilation) {
+    compilation.hooks.htmlWebpackPluginAlterAssetTags.tapAsync('html-webpack-inline-source-plugin', function (htmlPluginData, callback) {
       // Skip if the plugin configuration didn't set `inlineSource`
       if (!htmlPluginData.plugin.options.inlineSource) {
-        return htmlPluginData;
+        return callback(null, htmlPluginData);
       }
 
       var regexStr = htmlPluginData.plugin.options.inlineSource;
 
       var result = self.processTags(compilation, regexStr, htmlPluginData);
 
-      return result;
+      callback(null, result);
     });
   });
 };

--- a/index.js
+++ b/index.js
@@ -14,17 +14,17 @@ HtmlWebpackInlineSourcePlugin.prototype.apply = function (compiler) {
 
   // Hook into the html-webpack-plugin processing
   compiler.plugin('compilation', function (compilation) {
-    compilation.plugin('html-webpack-plugin-alter-asset-tags', function (htmlPluginData, callback) {
+    compilation.plugin('html-webpack-plugin-alter-asset-tags', function (htmlPluginData) {
       // Skip if the plugin configuration didn't set `inlineSource`
       if (!htmlPluginData.plugin.options.inlineSource) {
-        return callback(null, htmlPluginData);
+        return htmlPluginData;
       }
 
       var regexStr = htmlPluginData.plugin.options.inlineSource;
 
       var result = self.processTags(compilation, regexStr, htmlPluginData);
 
-      callback(null, result);
+      return result;
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -30,15 +30,15 @@
   },
   "homepage": "https://github.com/dustinjackson/html-webpack-inline-source-plugin",
   "devDependencies": {
-    "cheerio": "^0.22.0",
-    "css-loader": "^0.25.0",
-    "extract-text-webpack-plugin": "^1.0.1",
-    "html-webpack-plugin": "^2.16.0",
-    "jasmine": "^2.4.1",
+    "cheerio": "^1.0.0-rc.2",
+    "css-loader": "^0.28.10",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
+    "html-webpack-plugin": "^3.0.1",
+    "jasmine": "^3.1.0",
     "rimraf": "^2.5.2",
     "semistandard": "^7.0.5",
-    "style-loader": "^0.13.1",
-    "webpack": "^1.13.0"
+    "style-loader": "^0.20.2",
+    "webpack": "^4.0.1"
   },
   "dependencies": {
     "escape-string-regexp": "^1.0.5",

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -22,7 +22,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         path: OUTPUT_DIR
       },
       module: {
-        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+        rules: [{ test: /\.css$/, use: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
       },
       plugins: [
         new ExtractTextPlugin('style.css'),
@@ -35,7 +35,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
       fs.readFile(htmlFile, 'utf8', function (er, data) {
         expect(er).toBeFalsy();
         var $ = cheerio.load(data);
-        expect($('script[src="bundle.js"]').html()).toBe('');
+        expect($('script[src="main.js"]').html()).toBe('');
         expect($('link[href="style.css"]').html()).toBe('');
         done();
       });
@@ -54,7 +54,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         path: OUTPUT_DIR
       },
       module: {
-        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+        rules: [{ test: /\.css$/, use: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
       },
       // generate sourcemaps for testing URL correction
       devtool: '#source-map',
@@ -89,7 +89,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         path: OUTPUT_DIR
       },
       module: {
-        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+        rules: [{ test: /\.css$/, use: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
       },
       plugins: [
         new ExtractTextPlugin('style.css?[hash]'),
@@ -120,7 +120,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         path: OUTPUT_DIR
       },
       module: {
-        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+        rules: [{ test: /\.css$/, use: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
       },
       plugins: [
         new ExtractTextPlugin('style.css'),


### PR DESCRIPTION
I updated most of the dependencies and fixed the unit tests. Currently an beta release of the `extract-text-webpack-plugin` needs to be used cause of https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/701. I hope it would be possible to release a beta release of this plugin, until all other plugins are stable too.