### PR TITLE
Fix error when HtmlWebpackPlugin filename has subfolder

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,13 +40,14 @@ HtmlWebpackInlineSourcePlugin.prototype.processTags = function (compilation, reg
   var head = [];
 
   var regex = new RegExp(regexStr);
+  var filename = pluginData.plugin.options.filename;
 
   pluginData.head.forEach(function (tag) {
-    head.push(self.processTag(compilation, regex, tag));
+    head.push(self.processTag(compilation, regex, tag, filename));
   });
 
   pluginData.body.forEach(function (tag) {
-    body.push(self.processTag(compilation, regex, tag));
+    body.push(self.processTag(compilation, regex, tag, filename));
   });
 
   return { head: head, body: body, plugin: pluginData.plugin, chunks: pluginData.chunks, outputName: pluginData.outputName };
@@ -83,7 +84,7 @@ HtmlWebpackInlineSourcePlugin.prototype.resolveSourceMaps = function (compilatio
   });
 };
 
-HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, regex, tag) {
+HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, regex, tag, filename) {
   var assetUrl;
 
   // inline js
@@ -112,6 +113,10 @@ HtmlWebpackInlineSourcePlugin.prototype.processTag = function (compilation, rege
   if (assetUrl) {
     // Strip public URL prefix from asset URL to get Webpack asset name
     var publicUrlPrefix = compilation.outputOptions.publicPath || '';
+    // if filename is in subfolder, assetUrl should be prepended folder path
+    if (path.basename(filename) !== filename) {
+      assetUrl = path.dirname(filename) + '/' + assetUrl;
+    }
     var assetName = path.posix.relative(publicUrlPrefix, assetUrl);
     var asset = compilation.assets[assetName];
     var updatedSource = this.resolveSourceMaps(compilation, assetName, asset);

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -141,4 +141,35 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
       });
     });
   });
+
+  it('should embed source and not error if html in subfolder', function (done) {
+    webpack({
+      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      output: {
+        filename: 'bin/app.js',
+        path: OUTPUT_DIR
+      },
+      module: {
+        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+      },
+      plugins: [
+        new ExtractTextPlugin('style.css'),
+        new HtmlWebpackPlugin({
+          filename: 'subfolder/index.html',
+          inlineSource: '.(js|css)$'
+        }),
+        new HtmlWebpackInlineSourcePlugin()
+      ]
+    }, function (err) {
+      expect(err).toBeFalsy();
+      var htmlFile = path.resolve(OUTPUT_DIR, 'subfolder/index.html');
+      fs.readFile(htmlFile, 'utf8', function (er, data) {
+        expect(er).toBeFalsy();
+        var $ = cheerio.load(data);
+        expect($('script').html()).toContain('.embedded.source');
+        expect($('style').html()).toContain('.embedded.source');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
The sscce example is below

```
webpack({
      entry: path.join(__dirname, 'fixtures', 'entry.js'),
      output: {
        filename: 'bin/app.js',
        path: OUTPUT_DIR
      },
      module: {
        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
      },
      plugins: [
        new ExtractTextPlugin('style.css'),
        new HtmlWebpackPlugin({
          // !note there is subfolder
          filename: 'subfolder/index.html',
          inlineSource: '.(js|css)$'
        }),
        new HtmlWebpackInlineSourcePlugin()
      ]
    }
```