### PR TITLE
Make plugin compatible with the HTML Webpack Plugin version 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
+  - stable
+  - lts/*
+  - 6.9
 script:
   - npm test

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ plugins: [
   new HtmlWebpackPlugin({
 		inlineSource: '.(js|css)$' // embed all javascript and css inline
 	}),
-  new HtmlWebpackInlineSourcePlugin()
+  new HtmlWebpackInlineSourcePlugin(HtmlWebpackPlugin)
 ]  
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Inline Source extension for the HTML Webpack Plugin
 Enhances [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin)
 functionality by adding the `{inlineSource: 'regex string'}` option.
 
-This is an extension plugin for the [webpack](http://webpack.github.io) plugin [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin).  It allows you to embed javascript and css source inline.
+This is an extension plugin for the [webpack](http://webpack.github.io) plugin [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) (version 4 or higher).  It allows you to embed javascript and css source inline.
 
 Installation
 ------------
-You must be running webpack on node 4 or higher
+You must be running webpack on node 6 or higher.
 
 Install the plugin with npm:
 ```shell
@@ -29,7 +29,7 @@ Add the plugin to your webpack config as follows:
 ```javascript
 plugins: [
   new HtmlWebpackPlugin(),
-  new HtmlWebpackInlineSourcePlugin()
+  new HtmlWebpackInlineSourcePlugin(HtmlWebpackPlugin)
 ]  
 ```
 The above configuration will actually do nothing due to the configuration defaults.

--- a/index.js
+++ b/index.js
@@ -36,13 +36,14 @@ HtmlWebpackInlineSourcePlugin.prototype.processTags = function (compilation, reg
   var headTags = [];
 
   var regex = new RegExp(regexStr);
+  var filename = pluginData.plugin.options.filename;
 
   pluginData.headTags.forEach(function (tag) {
-    headTags.push(self.processTag(compilation, regex, tag));
+    headTags.push(self.processTag(compilation, regex, tag, filename));
   });
 
   pluginData.bodyTags.forEach(function (tag) {
-    bodyTags.push(self.processTag(compilation, regex, tag));
+    bodyTags.push(self.processTag(compilation, regex, tag, filename));
   });
 
   return { headTags: headTags, bodyTags: bodyTags, plugin: pluginData.plugin, outputName: pluginData.outputName };

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ HtmlWebpackInlineSourcePlugin.prototype.apply = function (compiler) {
         var result = self.processTags(compilation, regexStr, htmlPluginData);
 
         callback(null, result);
-      })
-  })
+      });
+  });
 };
 
 HtmlWebpackInlineSourcePlugin.prototype.processTags = function (compilation, regexStr, pluginData) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var path = require('path');
 var slash = require('slash');
 var sourceMapUrl = require('source-map-url');
 
-function HtmlWebpackInlineSourcePlugin (htmlWebpackPlugin, options) {
+function HtmlWebpackInlineSourcePlugin (htmlWebpackPlugin) {
   this.htmlWebpackPlugin = htmlWebpackPlugin;
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cheerio": "^0.22.0",
     "css-loader": "^0.25.0",
     "extract-text-webpack-plugin": "^1.0.1",
-    "html-webpack-plugin": "^2.16.0",
+    "html-webpack-plugin": "^4.0.0-beta.4",
     "jasmine": "^2.4.1",
     "rimraf": "^2.5.2",
     "semistandard": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "cheerio": "^0.22.0",
     "css-loader": "^0.25.0",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "^3.0.2",
     "html-webpack-plugin": "^4.0.0-beta.4",
     "jasmine": "^2.4.1",
     "rimraf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "cheerio": "^0.22.0",
     "css-loader": "^0.25.0",
-    "extract-text-webpack-plugin": "^3.0.2",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "html-webpack-plugin": "^4.0.0-beta.4",
     "jasmine": "^2.4.1",
     "rimraf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rimraf": "^2.5.2",
     "semistandard": "^7.0.5",
     "style-loader": "^0.13.1",
-    "webpack": "^1.13.0"
+    "webpack": "^4.20.2"
   },
   "dependencies": {
     "escape-string-regexp": "^1.0.5",

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -39,7 +39,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         expect(er).toBeFalsy();
         var $ = cheerio.load(data);
         expect($('script[src="bundle.js"]').html()).toBeNull();
-        expect($('link[href="style.css"]').html()).toBeNull();
+        expect($('link[href="style.css"]').html()).toBe('');
         done();
       });
     });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -38,8 +38,8 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
       fs.readFile(htmlFile, 'utf8', function (er, data) {
         expect(er).toBeFalsy();
         var $ = cheerio.load(data);
-        expect($('script[src="bundle.js"]').html()).toBe('');
-        expect($('link[href="style.css"]').html()).toBe('');
+        expect($('script[src="bundle.js"]').html()).toBeNull();
+        expect($('link[href="style.css"]').html()).toBeNull();
         done();
       });
     });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -22,7 +22,10 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         path: OUTPUT_DIR
       },
       module: {
-        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+        rules: [{ test: /\.css$/, use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: 'css-loader'
+        }) }]
       },
       plugins: [
         new ExtractTextPlugin('style.css'),
@@ -54,7 +57,10 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         path: OUTPUT_DIR
       },
       module: {
-        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+        rules: [{ test: /\.css$/, use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: 'css-loader'
+        }) }]
       },
       // generate sourcemaps for testing URL correction
       devtool: '#source-map',
@@ -89,7 +95,10 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         path: OUTPUT_DIR
       },
       module: {
-        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+        rules: [{ test: /\.css$/, use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: 'css-loader'
+        }) }]
       },
       plugins: [
         new ExtractTextPlugin('style.css?[hash]'),
@@ -120,7 +129,10 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         path: OUTPUT_DIR
       },
       module: {
-        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+        rules: [{ test: /\.css$/, use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: 'css-loader'
+        }) }]
       },
       plugins: [
         new ExtractTextPlugin('style.css'),
@@ -150,7 +162,10 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         path: OUTPUT_DIR
       },
       module: {
-        loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }]
+        rules: [{ test: /\.css$/, use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: 'css-loader'
+        }) }]
       },
       plugins: [
         new ExtractTextPlugin('style.css'),

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -27,7 +27,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
       plugins: [
         new ExtractTextPlugin('style.css'),
         new HtmlWebpackPlugin(),
-        new HtmlWebpackInlineSourcePlugin()
+        new HtmlWebpackInlineSourcePlugin(HtmlWebpackPlugin)
       ]
     }, function (err) {
       expect(err).toBeFalsy();
@@ -63,7 +63,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         new HtmlWebpackPlugin({
           inlineSource: '.(js|css)$'
         }),
-        new HtmlWebpackInlineSourcePlugin()
+        new HtmlWebpackInlineSourcePlugin(HtmlWebpackPlugin)
       ]
     }, function (err) {
       expect(err).toBeFalsy();
@@ -97,7 +97,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
           // modified regex to accept query string
           inlineSource: '.(js|css)(\\?.*)?$'
         }),
-        new HtmlWebpackInlineSourcePlugin()
+        new HtmlWebpackInlineSourcePlugin(HtmlWebpackPlugin)
       ]
     }, function (err) {
       expect(err).toBeFalsy();
@@ -127,7 +127,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
         new HtmlWebpackPlugin({
           inlineSource: '.(js|css)$'
         }),
-        new HtmlWebpackInlineSourcePlugin()
+        new HtmlWebpackInlineSourcePlugin(HtmlWebpackPlugin)
       ]
     }, function (err) {
       expect(err).toBeFalsy();
@@ -158,7 +158,7 @@ describe('HtmlWebpackInlineSourcePlugin', function () {
           filename: 'subfolder/index.html',
           inlineSource: '.(js|css)$'
         }),
-        new HtmlWebpackInlineSourcePlugin()
+        new HtmlWebpackInlineSourcePlugin(HtmlWebpackPlugin)
       ]
     }, function (err) {
       expect(err).toBeFalsy();


### PR DESCRIPTION
A new version of HTML Webpack Plugin (version 4) changed the way how hooks are attached (and adds some new types of hooks/events), so I've updated also this plugin to be compatible.