### PR TITLE
Add constructor definition to TS type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
 import { Plugin } from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 export = HtmlWebpackInlineSourcePlugin;
-declare class HtmlWebpackInlineSourcePlugin extends Plugin { }
+declare class HtmlWebpackInlineSourcePlugin extends Plugin {
+  constructor(htmlWebpackPlugin: HtmlWebpackPlugin)
+}
 declare namespace HtmlWebpackInlineSourcePlugin { }


### PR DESCRIPTION
The TypeScript type definitions did not match the expected [constructor parameter](https://github.com/DustinJackson/html-webpack-inline-source-plugin/blob/master/index.js#L7). This PR adds that definition.